### PR TITLE
Update for Stardew Valley 1.2 & SMAPI 1.12, streamline build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,74 @@
-#Stardew Valley Mod Collection by dantheman999#
+This is a collection of Stardew Valley mods by dantheman999. Currently there's only one mod available.
 
-Currently there is only one mod available.
+**Variable Grass** adds a randomised chance for more or less plant growth per day.
 
-##Variable Grass##
-Adds randomised chance for more or less plant growth per day.
+Compatible with Stardew Valley 1.11+ on Linux, Mac, and Windows.
 
-**INI Settings**
+## Contents
+* [Installation](#installation)
+* [Configuration](#configuration)
+* [Versions](#versions)
+* [Compiling the mod](#compiling-the-mod)
 
- - MinIterations - Minimum iterations of grass growing function to perform
- - MaxIterations - Maximum iterations of grass growing function to perform
+## Installation
+1. [Install the latest version of SMAPI](https://github.com/Pathoschild/SMAPI/releases).
+2. Download the source code.
+3. Build the project in Visual Studio or MonoDevelop to automatically copy the files into your mod directory.
+4. Run the game using SMAPI.
 
-----------
+## Configuration
+The mod will work fine out of the box, but you can tweak its settings by editing the `config.json`
+file if you want. These are the available settings:
 
-##Installation##
-Assuming you have SMAPI installed, just go to %appdata%\Stardew Valley\Mods and extract the DLL and ini file if there is one. 
+| setting           | what it affects
+| ----------------- | -------------------
+| `MinIterations`   | The minimum iterations of grass growing function to perform.
+| `MaxIterations`   | The maximum iterations of grass growing function to perform.
 
-You can edit the .ini file for each mod to change how it behaves.
+## Versions
+1.0:
+* Initial version.
 
-----------
+1.1:
+* Fixed not growing at correct times.
+* Slightly improved.
 
-##Developing##
-Pull the source, and you will probably notice when you try to build there are a few errors. There are two dependancies at the moment, `SMAPI` and the games EXE itself. You will need to have the game to develop. Add them to the location the references are looking at.
+1.2:
+* Added ini file.
+* Internal cleanup.
 
-[If you need XNA, download the V4 redist here](https://www.microsoft.com/en-us/download/details.aspx?id=20914)
+1.3:
+* Updated to SMAPI 1.3+ and Stardew Valley 1.1+.
+* Standardised config file.
+
+## Compiling the mod
+This mod uses the [crossplatform build config](https://github.com/Pathoschild/Stardew.ModBuildConfig#readme)
+so it can be built on Linux, Mac, and Windows without changes. See [its documentation](https://github.com/Pathoschild/Stardew.ModBuildConfig#readme)
+for troubleshooting.
+
+### Compiling the mod for testing
+To compile the mod and add it to the mods directory:
+
+1. Rebuild the project in [Visual Studio](https://www.visualstudio.com/vs/community/) or [MonoDevelop](http://www.monodevelop.com/).  
+   <small>This will compile the code and package it into the mod directory.</small>
+2. Launch the project with debugging.  
+   <small>This will start the game through SMAPI and attach the Visual Studio debugger.</small>
+
+### Compiling the mod for release
+To package the mod for release:
+
+1. Delete the game's `Mods/VariableGrass` directory.  
+   <small>(This ensures the package is clean and has default configuration.)</small>
+2. Recompile the mod per the previous section.
+3. Launch the game through SMAPI to generate the default `config.json`.
+2. Create a zip file of the game's `Mods/VariableGrass` folder. The zip name should include the
+   mod name and version. For example:
+
+   ```
+   VariableGrass-1.3.zip
+      VariableGrass/
+         VariableGrass.dll
+         VariableGrass.pdb
+         config.json
+         manifest.json
+   ```

--- a/StardewMods.sln
+++ b/StardewMods.sln
@@ -1,9 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VariableGrass", "VariableGrass\VariableGrass.csproj", "{47D1C504-85D6-4AFE-A5BB-54F4B66E058A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "metadata", "metadata", "{1C4B0C05-0EC3-49C9-AB83-249336313A52}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/StardewMods.sln.DotSettings
+++ b/StardewMods.sln.DotSettings
@@ -1,0 +1,11 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeThisQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/StaticQualifier/STATIC_MEMBERS_QUALIFY_MEMBERS/@EntryValue">Field, Property, Event, Method</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">Field, Property, Event, Method</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForBuiltInTypes/@EntryValue">UseVarWhenEvident</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForOtherTypes/@EntryValue">UseVarWhenEvident</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForSimpleTypes/@EntryValue">UseVarWhenEvident</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+</wpf:ResourceDictionary>

--- a/VariableGrass/IniFile.cs
+++ b/VariableGrass/IniFile.cs
@@ -1,55 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace VariableGrass
+﻿namespace VariableGrass
 {
-    class IniFile   // revision 10
+    /// <summary>The configuration settings.</summary>
+    internal class IniFile
     {
-        string Path;
-        string EXE = Assembly.GetExecutingAssembly().GetName().Name;
+        /// <summary>The minimum grow iterations per day.</summary>
+        public int MinIterations { get; set; }
 
-        [DllImport("kernel32")]
-        static extern long WritePrivateProfileString(string Section, string Key, string Value, string FilePath);
-
-        [DllImport("kernel32")]
-        static extern int GetPrivateProfileString(string Section, string Key, string Default, StringBuilder RetVal, int Size, string FilePath);
-
-        public IniFile(string IniPath = null)
-        {
-            Path = new FileInfo(IniPath ?? EXE + ".ini").FullName.ToString();
-        }
-
-        public string Read(string Key, string Section = null)
-        {
-            var RetVal = new StringBuilder(255);
-            GetPrivateProfileString(Section ?? EXE, Key, "", RetVal, 255, Path);
-            return RetVal.ToString();
-        }
-
-        public void Write(string Key, string Value, string Section = null)
-        {
-            WritePrivateProfileString(Section ?? EXE, Key, Value, Path);
-        }
-
-        public void DeleteKey(string Key, string Section = null)
-        {
-            Write(Key, null, Section ?? EXE);
-        }
-
-        public void DeleteSection(string Section = null)
-        {
-            Write(null, null, Section ?? EXE);
-        }
-
-        public bool KeyExists(string Key, string Section = null)
-        {
-            return Read(Key, Section).Length > 0;
-        }
+        /// <summary>The maximum grow iterations per day.</summary>
+        public int MaxIterations { get; set; } = 2;
     }
 }

--- a/VariableGrass/ModConfig.cs
+++ b/VariableGrass/ModConfig.cs
@@ -1,7 +1,7 @@
 ﻿namespace VariableGrass
 {
     /// <summary>The configuration settings.</summary>
-    internal class IniFile
+    internal class ModConfig
     {
         /// <summary>The minimum grow iterations per day.</summary>
         public int MinIterations { get; set; }

--- a/VariableGrass/Properties/AssemblyInfo.cs
+++ b/VariableGrass/Properties/AssemblyInfo.cs
@@ -1,36 +1,9 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("LoadsOfGrass")]
+[assembly: AssemblyTitle("VariableGrass")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("LoadsOfGrass")]
 [assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("47d1c504-85d6-4afe-a5bb-54f4b66e058a")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/VariableGrass/VariableGrass.cs
+++ b/VariableGrass/VariableGrass.cs
@@ -33,17 +33,17 @@ namespace VariableGrass
             this.MaxIterations = config.MaxIterations;
 
             // register events
-            TimeEvents.DayOfMonthChanged += Events_DayOfMonthChanged;
+            TimeEvents.AfterDayStarted += this.TimeEvents_AfterDayStarted;
         }
 
 
         /*********
         ** Private methods
         *********/
-        /// <summary>The method called when the day number changes.</summary>
+        /// <summary>The method called after a new day starts.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event arguments.</param>
-        private void Events_DayOfMonthChanged(object sender, EventArgsIntChanged e)
+        private void TimeEvents_AfterDayStarted(object sender, EventArgs e)
         {
             int iterations = this.Random.Next(MinIterations, MaxIterations);
             this.Monitor.Log($"Growing grass ({iterations} iterations)...");

--- a/VariableGrass/VariableGrass.cs
+++ b/VariableGrass/VariableGrass.cs
@@ -1,68 +1,53 @@
-﻿using StardewModdingAPI;
-using StardewModdingAPI.Inheritance;
+﻿using System;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
 using StardewValley;
-using System;
 
 namespace VariableGrass
 {
     public class VariableGrass : Mod
     {
-        private const string MIN_ITERATIONS_KEY = "MinIterations";
-        private const string MAX_ITERATIONS_KEY = "MinIterations";
+        /*********
+        ** Properties
+        *********/
+        /// <summary>The minimum number of iterations.</summary>
+        private int MinIterations;
 
-        //Current day
-        private int day;
+        /// <summary>The maximum number of iterations.</summary>
+        private int MaxIterations;
 
-        //Minimum Iterations
-        private int min;
+        /// <summary>The random number generator.</summary>
+        private readonly Random Random = new Random();
 
-        //Maximum Iterations
-        private int max;
 
-        //Random gen
-        Random rnd = new Random();
-
-        public override string Name
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
+        public override void Entry(IModHelper helper)
         {
-            get { return "VariableGrass"; }
+            // get settings
+            var config = helper.ReadConfig<IniFile>();
+            this.MinIterations = config.MinIterations;
+            this.MaxIterations = config.MaxIterations;
+
+            // register events
+            TimeEvents.DayOfMonthChanged += Events_DayOfMonthChanged;
         }
 
-        public override string Authour
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>The method called when the day number changes.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void Events_DayOfMonthChanged(object sender, EventArgsIntChanged e)
         {
-            get { return "dantheman999"; }
-        }
-
-        public override string Version
-        {
-            get { return "1.2"; }
-        }
-
-        public override string Description
-        {
-            get { return "Grass grows at variable rates"; }
-        }
-
-        public override void Entry()
-        {
-            Events.DayOfMonthChanged += Events_DayOfMonthChanged;
-
-            //Get settings
-            var settings = new IniFile("VariableGrass.ini");
-            min = int.Parse(settings.Read(MIN_ITERATIONS_KEY));
-            max = int.Parse(settings.Read(MAX_ITERATIONS_KEY));
-        }
-
-        void Events_DayOfMonthChanged(int day)
-        {
-            if (!SGame.hasLoadedGame)
-                return;
-
-            Console.WriteLine("Getting farm...");
-            Farm farm = SGame.getLocationFromName("Farm") as Farm;
-            Console.WriteLine("Got farm... GROW!");
-            var growAmount = rnd.Next(min, max);
-            Console.WriteLine("Grow amount :: " + growAmount);
-            farm.growWeedGrass(growAmount);
+            int iterations = this.Random.Next(MinIterations, MaxIterations);
+            this.Monitor.Log($"Growing grass ({iterations} iterations)...");
+            Game1.getFarm().growWeedGrass(iterations);
         }
     }
 }

--- a/VariableGrass/VariableGrass.cs
+++ b/VariableGrass/VariableGrass.cs
@@ -28,7 +28,7 @@ namespace VariableGrass
         public override void Entry(IModHelper helper)
         {
             // get settings
-            var config = helper.ReadConfig<IniFile>();
+            var config = helper.ReadConfig<ModConfig>();
             this.MinIterations = config.MinIterations;
             this.MaxIterations = config.MaxIterations;
 

--- a/VariableGrass/VariableGrass.csproj
+++ b/VariableGrass/VariableGrass.csproj
@@ -30,21 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553" />
-    <Reference Include="Stardew Valley">
-      <HintPath>..\Libs\Stardew Valley.exe</HintPath>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\Libs\StardewModdingAPI.exe</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IniFile.cs" />
@@ -52,16 +38,24 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="VariableGrass.ini">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="manifest.json" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
   <Target Name="AfterBuild">
+    <PropertyGroup>
+      <ModPath>$(GamePath)\Mods\VariableGrass</ModPath>
+    </PropertyGroup>
+    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
+    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
+    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
+    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
   </Target>
-  -->
 </Project>

--- a/VariableGrass/VariableGrass.csproj
+++ b/VariableGrass/VariableGrass.csproj
@@ -33,7 +33,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="IniFile.cs" />
+    <Compile Include="ModConfig.cs" />
     <Compile Include="VariableGrass.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/VariableGrass/VariableGrass.ini
+++ b/VariableGrass/VariableGrass.ini
@@ -1,2 +1,0 @@
-﻿MinIterations=0
-MaxIterations=2

--- a/VariableGrass/manifest.json
+++ b/VariableGrass/manifest.json
@@ -3,7 +3,7 @@
   "Author": "dantheman999",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
+    "MinorVersion": 4,
     "PatchVersion": 0,
     "Build": null
   },

--- a/VariableGrass/manifest.json
+++ b/VariableGrass/manifest.json
@@ -1,0 +1,13 @@
+﻿{
+  "Name": "VariableGrass",
+  "Author": "dantheman999",
+  "Version": {
+    "MajorVersion": 1,
+    "MinorVersion": 2,
+    "PatchVersion": 0,
+    "Build": ""
+  },
+  "Description": "Grass grows at variable rates",
+  "UniqueID": "VariableGrass",
+  "EntryDll": "VariableGrass.dll"
+}

--- a/VariableGrass/manifest.json
+++ b/VariableGrass/manifest.json
@@ -5,9 +5,10 @@
     "MajorVersion": 1,
     "MinorVersion": 3,
     "PatchVersion": 0,
-    "Build": ""
+    "Build": null
   },
+  "MinimumApiVersion": "1.12",
   "Description": "Grass grows at variable rates",
-  "UniqueID": "VariableGrass",
+  "UniqueID": "dantheman999.VariableGrass",
   "EntryDll": "VariableGrass.dll"
 }

--- a/VariableGrass/manifest.json
+++ b/VariableGrass/manifest.json
@@ -3,7 +3,7 @@
   "Author": "dantheman999",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 2,
+    "MinorVersion": 3,
     "PatchVersion": 0,
     "Build": ""
   },

--- a/VariableGrass/packages.config
+++ b/VariableGrass/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This pull request...

* Updates the code for the latest Stardew Valley 1.2 and SMAPI 1.10.
* Updates and expands the `README`.
* Replaces the custom `.ini` file with SMAPI's config API.
* Migrates to the [mod build package](https://github.com/Pathoschild/Stardew.ModBuildConfig).  
  _This automates references (so we no longer need to change reference paths in the `.csproj`), lets us compile the mod on Linux/Mac/Windows without changes, and simplifies debugging from Visual Studio._
* Adds a build task to automatically package the mod into the `Mods` folder.

If these changes look fine, can you release [VariableGrass 1.4.zip](https://github.com/dantheman999301/StardewMods/files/977408/VariableGrass.1.4.zip) for players to use?